### PR TITLE
Read images from local

### DIFF
--- a/android/src/main/java/com/reactnativeimagegenerator/ImageGeneratorModule.kt
+++ b/android/src/main/java/com/reactnativeimagegenerator/ImageGeneratorModule.kt
@@ -44,6 +44,10 @@ class ImageGeneratorModule(reactContext: ReactApplicationContext) : ReactContext
       val url = URL(layer.uri);
       return BitmapFactory.decodeStream(url.openConnection().getInputStream())
     }
+    if ("file" in layer.uri) {
+      val imgFile = File(layer.uri.replace("file://", ""));
+      return BitmapFactory.decodeFile(imgFile.absolutePath);
+    }
     return BitmapFactory.decodeStream(reactApplicationContext.assets.open(layer.uri));
   }
 


### PR DESCRIPTION
With this patch we can read images from local file system.

```
import { generate } from 'react-native-image-generator';

// ...
const r = await generate(
  [
.......
.......
.......
    {
      uri: 'file:///data/user/0/com.anonymous.eleapp/files/270118522759973405.jpg',  //read image from local file system
      width: 200,
      height: 300,
      x: 0,
      y: 0,
    },
.......
.......
.......
);
```